### PR TITLE
Improve context size with context dictionary

### DIFF
--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -13,7 +13,7 @@ import {
   buildDMContext,
   buildEntityLookupContext,
   buildMentionsContext,
-  buildReplyContext,
+  buildReferenceContext,
   buildServerContext,
   type CollectedEntities,
 } from "../utils/ai/context/main";
@@ -76,7 +76,7 @@ export default {
         "{% clear_history_before %}",
       );
 
-      await buildReplyContext(context, message, allMentionedEntities);
+      await buildReferenceContext(context, message, allMentionedEntities);
       buildMentionsContext(context, message, allMentionedEntities);
       buildEntityLookupContext(context, allMentionedEntities);
 

--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -22,12 +22,6 @@ import { buildImageParts } from "../utils/ai/imageParts";
 import { Context } from "../utils/contextBuilder";
 import { escapeMentions } from "../utils/escapeMentions";
 import { logger } from "../utils/logger";
-// @@ REMOVE LATER
-import * as fs from "node:fs";
-import * as path from "node:path";
-
-const CONTEXT_DIR = path.join(__dirname, "../data/context");
-// @@ END REMOVE LATER
 
 export default {
   event: Events.MessageCreate,
@@ -95,23 +89,6 @@ export default {
         role: "user",
         parts: currentMessageParts,
       });
-
-      // @@ REMOVE LATER - Save context to file
-      if (!fs.existsSync(CONTEXT_DIR)) {
-        fs.mkdirSync(CONTEXT_DIR, { recursive: true });
-      }
-      const contextFilePath = path.join(CONTEXT_DIR, `${message.id}.html`);
-      fs.writeFileSync(contextFilePath, context.toString());
-      const messageHistoryFilePath = path.join(
-        CONTEXT_DIR,
-        `${message.id}.json`,
-      );
-      fs.writeFileSync(
-        messageHistoryFilePath,
-        JSON.stringify(conversationHistory),
-      );
-      logger.log(`Context saved to ${contextFilePath}`);
-      // @@ END REMOVE LATER
 
       const guildId = message.guild?.id;
 

--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -100,7 +100,7 @@ export default {
       if (!fs.existsSync(CONTEXT_DIR)) {
         fs.mkdirSync(CONTEXT_DIR, { recursive: true });
       }
-      const contextFilePath = path.join(CONTEXT_DIR, `${message.id}.xml`);
+      const contextFilePath = path.join(CONTEXT_DIR, `${message.id}.html`);
       fs.writeFileSync(contextFilePath, context.toString());
       const messageHistoryFilePath = path.join(
         CONTEXT_DIR,

--- a/utils/ai/context/history.ts
+++ b/utils/ai/context/history.ts
@@ -23,11 +23,23 @@ export async function buildConversationHistory(
       .filter((msg) => msg.id !== message.id)
       .reverse();
 
-    const clearMarkerIndex = history.findIndex((msg) =>
-      msg.content.includes(clearHistoryMarker),
-    );
-    if (clearMarkerIndex !== -1) {
-      historyStartIndex = clearMarkerIndex + 1;
+    let lastMarkerIndex = -1;
+    let currentIndex = 0;
+    while (currentIndex < history.length) {
+      const nextMarkerIndex = history.findIndex(
+        (msg, index) =>
+          index >= currentIndex && msg.content.includes(clearHistoryMarker),
+      );
+      if (nextMarkerIndex !== -1) {
+        lastMarkerIndex = nextMarkerIndex;
+        currentIndex = nextMarkerIndex + 1;
+      } else {
+        break;
+      }
+    }
+
+    if (lastMarkerIndex !== -1) {
+      historyStartIndex = lastMarkerIndex + 1;
     }
 
     for (let i = historyStartIndex; i < history.length; i++) {

--- a/utils/ai/context/history.ts
+++ b/utils/ai/context/history.ts
@@ -1,47 +1,118 @@
-import { Client, Message, TextChannel } from "discord.js";
+import { Client, Message, TextChannel } from "discord.js"; // Added imports
 import { Context } from "../../contextBuilder";
+import { logger } from "../../logger"; // Assuming logger is available
+// Import helpers from main.ts to add entities to collection
 import {
-  buildMentionsContext,
-  buildReplyContext,
-  buildUserContext,
+  addChannelToCollection,
+  addRoleToCollection,
+  addUserToCollection,
+  type CollectedEntities,
 } from "./main";
 
 export async function buildConversationHistory(
   client: Client,
   message: Message,
+  allMentionedEntities: CollectedEntities, // Pass the main collection here
   clearHistoryMarker: string = "{% clear_history_before %}",
-) {
+): Promise<Array<{ role: string; parts: Array<{ text: string }> }>> {
+  // Return only the history array
   const conversationHistory = [];
   let historyStartIndex = 0;
 
   if (message.channel instanceof TextChannel) {
-    const messages = await message.channel.messages.fetch({ limit: 50 });
-    const history = Array.from(messages.values()).reverse();
+    // Fetch more messages to ensure history is useful, maybe 100? Adjust limit as needed.
+    const messages = await message.channel.messages.fetch({ limit: 100 });
+    // Filter out the current message itself before processing history
+    const history = Array.from(messages.values())
+      .filter((msg) => msg.id !== message.id)
+      .reverse();
 
-    for (let i = history.length - 2; i >= 0; i--) {
-      const msg = history[i];
-      if (msg.content.includes(clearHistoryMarker)) {
-        historyStartIndex = i;
-        break;
-      }
+    // Find the clear history marker (excluding the current message)
+    const clearMarkerIndex = history.findIndex((msg) =>
+      msg.content.includes(clearHistoryMarker),
+    );
+    if (clearMarkerIndex !== -1) {
+      historyStartIndex = clearMarkerIndex + 1; // Start from the message *after* the marker
     }
 
-    for (let i = historyStartIndex; i < history.length - 1; i++) {
+    for (let i = historyStartIndex; i < history.length; i++) {
+      // Iterate up to the end of the history array (before the current message)
       const msg = history[i];
       const historyContext = new Context();
 
-      buildMentionsContext(historyContext, msg);
-      await buildReplyContext(historyContext, msg);
-
+      // --- Simplified context for history messages ---
       historyContext.add("message-timestamp", msg.createdAt.toISOString());
+      historyContext.add("message-id", msg.id); // Add message ID
+
+      // Always add the author of the history message to the main collection
+      addUserToCollection(allMentionedEntities, msg.author, msg.member);
 
       if (msg.author.id === client.user?.id) {
+        // Model message - just content
         conversationHistory.push({
           role: "model",
           parts: [{ text: msg?.content || "Error: No message content" }],
         });
       } else {
-        buildUserContext(historyContext, msg);
+        // User message - minimal context + content
+        historyContext.add("user-id", msg.author.id); // Add user ID
+        // Optionally add user name for easier reading, but ID is key for lookup
+        const member = msg.guild?.members.cache.get(msg.author.id);
+        const name = member?.nickname || msg.author.displayName;
+        historyContext.add("user-name", name);
+
+        // Collect mentions from this history message and add to the main collection
+        msg.mentions.users.forEach((user) =>
+          addUserToCollection(
+            allMentionedEntities,
+            user,
+            msg.guild?.members.cache.get(user.id),
+          ),
+        );
+        msg.mentions.roles.forEach((role) =>
+          addRoleToCollection(allMentionedEntities, role),
+        );
+        msg.mentions.channels.forEach((channel) => {
+          // Try to add channel to the collection (name might be missing for partial)
+          addChannelToCollection(allMentionedEntities, channel);
+        });
+
+        // Collect author of referenced message if it's a reply and add to main collection
+        if (msg.reference?.messageId) {
+          // We *must* fetch the referenced message to get its author and mentions reliably
+          try {
+            const referencedMsg = await msg.fetchReference();
+            addUserToCollection(
+              allMentionedEntities,
+              referencedMsg.author,
+              referencedMsg.member,
+            );
+
+            // Also collect mentions *within* the referenced message for the global pool
+            referencedMsg.mentions.users.forEach((user) =>
+              addUserToCollection(
+                allMentionedEntities,
+                user,
+                referencedMsg.guild?.members.cache.get(user.id),
+              ),
+            );
+            referencedMsg.mentions.roles.forEach((role) =>
+              addRoleToCollection(allMentionedEntities, role),
+            );
+            referencedMsg.mentions.channels.forEach((channel) => {
+              addChannelToCollection(allMentionedEntities, channel);
+            });
+
+            // Add referenced message ID to history context (optional, but helpful)
+            historyContext.add("reply-to-message-id", referencedMsg.id);
+            historyContext.add("reply-to-user-id", referencedMsg.author.id);
+          } catch (err) {
+            // Log error but continue
+            logger.warn(
+              `Could not fetch referenced message ${msg.reference.messageId} for history message ${msg.id}: ${err}`,
+            );
+          }
+        }
 
         conversationHistory.push({
           role: "user",
@@ -55,5 +126,5 @@ export async function buildConversationHistory(
     }
   }
 
-  return conversationHistory;
+  return conversationHistory; // Return only the history array
 }

--- a/utils/ai/context/history.ts
+++ b/utils/ai/context/history.ts
@@ -1,7 +1,6 @@
-import { Client, Message, TextChannel } from "discord.js"; // Added imports
+import { Client, Message, TextChannel } from "discord.js";
 import { Context } from "../../contextBuilder";
-import { logger } from "../../logger"; // Assuming logger is available
-// Import helpers from main.ts to add entities to collection
+import { logger } from "../../logger";
 import {
   addChannelToCollection,
   addRoleToCollection,
@@ -12,56 +11,45 @@ import {
 export async function buildConversationHistory(
   client: Client,
   message: Message,
-  allMentionedEntities: CollectedEntities, // Pass the main collection here
+  allMentionedEntities: CollectedEntities,
   clearHistoryMarker: string = "{% clear_history_before %}",
 ): Promise<Array<{ role: string; parts: Array<{ text: string }> }>> {
-  // Return only the history array
   const conversationHistory = [];
   let historyStartIndex = 0;
 
   if (message.channel instanceof TextChannel) {
-    // Fetch more messages to ensure history is useful, maybe 100? Adjust limit as needed.
-    const messages = await message.channel.messages.fetch({ limit: 100 });
-    // Filter out the current message itself before processing history
+    const messages = await message.channel.messages.fetch({ limit: 50 });
     const history = Array.from(messages.values())
       .filter((msg) => msg.id !== message.id)
       .reverse();
 
-    // Find the clear history marker (excluding the current message)
     const clearMarkerIndex = history.findIndex((msg) =>
       msg.content.includes(clearHistoryMarker),
     );
     if (clearMarkerIndex !== -1) {
-      historyStartIndex = clearMarkerIndex + 1; // Start from the message *after* the marker
+      historyStartIndex = clearMarkerIndex + 1;
     }
 
     for (let i = historyStartIndex; i < history.length; i++) {
-      // Iterate up to the end of the history array (before the current message)
       const msg = history[i];
       const historyContext = new Context();
 
-      // --- Simplified context for history messages ---
       historyContext.add("message-timestamp", msg.createdAt.toISOString());
-      historyContext.add("message-id", msg.id); // Add message ID
+      historyContext.add("message-id", msg.id);
 
-      // Always add the author of the history message to the main collection
       addUserToCollection(allMentionedEntities, msg.author, msg.member);
 
       if (msg.author.id === client.user?.id) {
-        // Model message - just content
         conversationHistory.push({
           role: "model",
           parts: [{ text: msg?.content || "Error: No message content" }],
         });
       } else {
-        // User message - minimal context + content
-        historyContext.add("user-id", msg.author.id); // Add user ID
-        // Optionally add user name for easier reading, but ID is key for lookup
+        historyContext.add("user-id", msg.author.id);
         const member = msg.guild?.members.cache.get(msg.author.id);
         const name = member?.nickname || msg.author.displayName;
         historyContext.add("user-name", name);
 
-        // Collect mentions from this history message and add to the main collection
         msg.mentions.users.forEach((user) =>
           addUserToCollection(
             allMentionedEntities,
@@ -73,13 +61,10 @@ export async function buildConversationHistory(
           addRoleToCollection(allMentionedEntities, role),
         );
         msg.mentions.channels.forEach((channel) => {
-          // Try to add channel to the collection (name might be missing for partial)
           addChannelToCollection(allMentionedEntities, channel);
         });
 
-        // Collect author of referenced message if it's a reply and add to main collection
         if (msg.reference?.messageId) {
-          // We *must* fetch the referenced message to get its author and mentions reliably
           try {
             const referencedMsg = await msg.fetchReference();
             addUserToCollection(
@@ -88,7 +73,6 @@ export async function buildConversationHistory(
               referencedMsg.member,
             );
 
-            // Also collect mentions *within* the referenced message for the global pool
             referencedMsg.mentions.users.forEach((user) =>
               addUserToCollection(
                 allMentionedEntities,
@@ -103,11 +87,9 @@ export async function buildConversationHistory(
               addChannelToCollection(allMentionedEntities, channel);
             });
 
-            // Add referenced message ID to history context (optional, but helpful)
             historyContext.add("reply-to-message-id", referencedMsg.id);
             historyContext.add("reply-to-user-id", referencedMsg.author.id);
           } catch (err) {
-            // Log error but continue
             logger.warn(
               `Could not fetch referenced message ${msg.reference.messageId} for history message ${msg.id}: ${err}`,
             );
@@ -126,5 +108,5 @@ export async function buildConversationHistory(
     }
   }
 
-  return conversationHistory; // Return only the history array
+  return conversationHistory;
 }

--- a/utils/ai/context/main.ts
+++ b/utils/ai/context/main.ts
@@ -1,98 +1,153 @@
-import { Message } from "discord.js";
+import { type Channel, GuildMember, Message, Role, User } from "discord.js";
 import client from "../../../clients/discord";
 import { Context } from "../../contextBuilder";
+import { logger } from "../../logger";
 
-export function buildServerContext(context: Context, message: Message) {
-  const serverAttributes = context
-    .add("server-attributes")
-    .desc("Details about the server the message was sent in");
-  serverAttributes.add("id", message.guild?.id || "");
-  serverAttributes.add("name", message.guild?.name || "");
-  serverAttributes.add(
-    "member-count",
-    message.guild?.memberCount?.toString() || "",
-  );
+// Define the structure for collected entities (Exported for use in history.ts)
+export interface CollectedEntities {
+  users: Map<
+    string,
+    { id: string; name: string; isBot?: boolean; isSelf?: boolean }
+  >;
+  roles: Map<string, { id: string; name: string }>;
+  channels: Map<string, { id: string; name: string }>;
 }
 
-export function buildChannelContext(context: Context, message: Message) {
-  const channelAttributes = context
-    .add("channel-attributes")
-    .desc("Details about the channel the message was sent in");
-  channelAttributes.add("id", message.channel.id);
-  // @ts-ignore
-  channelAttributes.add("name", message.channel?.name || "Unknown");
-}
-
-export function buildDMContext(context: Context, message: Message) {
-  const channelAttributes = context
-    .add("channel-attributes")
-    .desc("Details about the direct message channel");
-  channelAttributes.add("id", message.channel.id);
-  channelAttributes.add("name", "Direct Message");
-  channelAttributes.add("is-dm", "true");
-}
-
-export function buildUserContext(context: Context, message: Message) {
-  const userAttributes = context
-    .add("user-attributes")
-    .desc("Details about the user who sent the message");
-  userAttributes.add("id", message.author.id);
-  if (message.member?.nickname) {
-    userAttributes
-      .add("name", message.member?.nickname)
-      .desc("Server nickname (preferred)");
-  } else {
-    userAttributes
-      .add("name", message.author.displayName)
-      .desc("Discord display name (preferred)");
-  }
-
-  if (message.author.id === client.user?.id) {
-    userAttributes.add("is-self", "true").desc("You (@Capybot)");
-  }
-  if (message.author.bot) {
-    userAttributes.add("is-bot", "true");
-  }
-}
-
-export async function buildReplyContext(context: Context, message: Message) {
-  if (!message.reference) return;
-
-  const replyAttributes = context
-    .add("reply-data")
-    .desc("The sent message is a reply to another message");
-
-  try {
-    const referencedMessage = await message.fetchReference();
-    const replyMessageAttributes = replyAttributes
-      .add("message-attributes")
-      .desc("Details about the referenced message");
-    replyMessageAttributes.add("id", referencedMessage.id);
-    replyMessageAttributes.add("content", referencedMessage.content);
-
-    const userAttrs = replyMessageAttributes.add("user-attributes");
-    userAttrs.add("id", referencedMessage.author.id);
-    if (referencedMessage.member?.nickname) {
-      userAttrs
-        .add("name", referencedMessage.member?.nickname)
-        .desc("Server nickname (preferred)");
+// Helper to add user to the collection map
+// Can accept a full User/GuildMember object or just partial details if coming from history
+export function addUserToCollection(
+  entities: CollectedEntities,
+  user: User | { id: string; name: string; isBot?: boolean; isSelf?: boolean },
+  member?: GuildMember | null, // Optional member for nickname
+) {
+  if (!entities.users.has(user.id)) {
+    // If we have a full User object
+    if ("displayName" in user) {
+      const fullUser = user as User;
+      const name = member?.nickname || fullUser.displayName;
+      entities.users.set(fullUser.id, {
+        id: fullUser.id,
+        name: name,
+        isBot: fullUser.bot,
+        isSelf: fullUser.id === client.user?.id,
+      });
     } else {
-      userAttrs
-        .add("name", referencedMessage.author.displayName)
-        .desc("Discord display name (preferred)");
+      // Assume it's the partial details object from history
+      const partialUser = user as {
+        id: string;
+        name: string;
+        isBot?: boolean;
+        isSelf?: boolean;
+      };
+      entities.users.set(partialUser.id, {
+        id: partialUser.id,
+        name: partialUser.name,
+        isBot: partialUser.isBot,
+        isSelf: partialUser.isSelf,
+      });
     }
-    if (referencedMessage.author.id === client.user?.id) {
-      userAttrs.add("is-self", "true").desc("You (@Capybot)");
-    }
-    if (referencedMessage.author.bot) {
-      userAttrs.add("is-bot", "true");
-    }
-  } catch (error) {
-    replyAttributes.add("error", "Could not fetch referenced message");
   }
 }
 
-export function buildMentionsContext(context: Context, message: Message) {
+// Helper to add role to the collection map
+export function addRoleToCollection(
+  entities: CollectedEntities,
+  role: Role | { id: string; name: string },
+) {
+  if (!entities.roles.has(role.id)) {
+    entities.roles.set(role.id, {
+      id: role.id,
+      name: role.name,
+    });
+  }
+}
+
+// Helper to add channel to the collection map
+export function addChannelToCollection(
+  entities: CollectedEntities,
+  channel: Channel | { id: string; name: string },
+) {
+  if (!entities.channels.has(channel.id)) {
+    // If we have a full Channel object (like GuildChannel)
+    if ("name" in channel && typeof channel.name === "string") {
+      entities.channels.set(channel.id, {
+        id: channel.id,
+        name: channel.name,
+      });
+    } else {
+      // Assume it's the partial details object
+      const partialChannel = channel as { id: string; name: string };
+      entities.channels.set(partialChannel.id, {
+        id: partialChannel.id,
+        name: partialChannel.name,
+      });
+    }
+  }
+}
+
+// New function to build the centralized entity lookup context
+export function buildEntityLookupContext(
+  context: Context,
+  entities: CollectedEntities,
+) {
+  if (
+    entities.users.size === 0 &&
+    entities.roles.size === 0 &&
+    entities.channels.size === 0
+  ) {
+    return; // Skip if no entities collected
+  }
+
+  const entityDetails = context
+    .add("entity-details")
+    .desc(
+      "Lookup table for users, roles, and channels mentioned in the conversation (history + current message)",
+    );
+
+  if (entities.users.size > 0) {
+    const usersNode = entityDetails
+      .add("users")
+      .desc("Details for users keyed by ID");
+    for (const [id, details] of entities.users.entries()) {
+      const userNode = usersNode.add(id);
+      userNode.add("id", details.id);
+      userNode.add("name", details.name);
+      if (details.isBot) userNode.add("is-bot", "true");
+      if (details.isSelf)
+        userNode.add("is-self", "true").desc("You (@Capybot)");
+    }
+  }
+
+  if (entities.roles.size > 0) {
+    const rolesNode = entityDetails
+      .add("roles")
+      .desc("Details for roles keyed by ID");
+    for (const [id, details] of entities.roles.entries()) {
+      const roleNode = rolesNode.add(id);
+      roleNode.add("id", details.id);
+      roleNode.add("name", details.name);
+    }
+  }
+
+  if (entities.channels.size > 0) {
+    const channelsNode = entityDetails
+      .add("channels")
+      .desc("Details for channels keyed by ID");
+    for (const [id, details] of entities.channels.entries()) {
+      const channelNode = channelsNode.add(id);
+      channelNode.add("id", details.id);
+      channelNode.add("name", details.name);
+    }
+  }
+}
+
+// Modify buildMentionsContext to use the entity collection
+export function buildMentionsContext(
+  context: Context,
+  message: Message,
+  entities: CollectedEntities,
+) {
+  // Add entities parameter
   const botMentioned = message.mentions.users.has(
     client.user?.id || "dummy_id_to_prevent_undefined_lookup",
   );
@@ -111,71 +166,75 @@ export function buildMentionsContext(context: Context, message: Message) {
   if (!hasMentions) return;
 
   const mentionsContext = context
-    .add("mentions")
-    .desc("Information about mentions found in the message content");
+    .add("mentions-in-current-message") // Rename to be specific
+    .desc(
+      "Information about mentions found *only* in the current message content. Refer to 'entity-details' for full information about these IDs.",
+    );
 
-  const mentionedUserNames: string[] = [];
-  const mentionedChannelNames: string[] = [];
-  const mentionedRoleNames: string[] = [];
+  const mentionedUserIds: string[] = []; // Collect IDs for listing
+  const mentionedChannelIds: string[] = [];
+  const mentionedRoleIds: string[] = [];
   let everyoneMentioned = false;
 
+  const mentionedUserNames: string[] = []; // Still collect names for summary
+  const mentionedChannelNames: string[] = [];
+  const mentionedRoleNames: string[] = [];
+
   if (message.mentions.users.size > 0) {
-    const userMentions = mentionsContext
-      .add("users")
-      .desc("User mentions found in the message");
     message.mentions.users.forEach((user) => {
-      const userMention = userMentions
-        .add(`user-${user.id}`)
-        .desc(`Details for user mention with ID ${user.id}`);
-      userMention.add("id", user.id);
-      const member = message.guild?.members.cache.get(user.id);
-      const name = member?.nickname || user.displayName;
-      const nameDesc = member?.nickname
-        ? "Server nickname (preferred)"
-        : "Discord display name (preferred)";
-      userMention.add("name", name).desc(nameDesc);
-
-      mentionedUserNames.push(
-        `${name}${user.id === client.user?.id ? " (You)" : ""}`,
+      // Add user to the global collection (in case they weren't in history)
+      addUserToCollection(
+        entities,
+        user,
+        message.guild?.members.cache.get(user.id),
       );
+      mentionedUserIds.push(user.id); // List IDs in current message context
 
-      if (user.bot) {
-        userMention.add("is-bot", "true");
-      }
-      if (user.id === client.user?.id) {
-        userMention.add("is-self", "true").desc("You (@Capybot)");
+      // Get name for summary from the collection
+      const userDetails = entities.users.get(user.id);
+      if (userDetails) {
+        mentionedUserNames.push(
+          `${userDetails.name}${userDetails.isSelf ? " (You)" : ""}`,
+        );
       }
     });
+    if (mentionedUserIds.length > 0) {
+      mentionsContext.add("user-ids", mentionedUserIds.join(", ")); // List IDs
+    }
   }
 
   if (message.mentions.channels.size > 0) {
-    const channelMentions = mentionsContext
-      .add("channels")
-      .desc("Channel mentions found in the message");
     message.mentions.channels.forEach((channel) => {
-      const channelMention = channelMentions
-        .add(`channel-${channel.id}`)
-        .desc(`Details for channel mention with ID ${channel.id}`);
-      channelMention.add("id", channel.id);
-      if ("name" in channel && typeof channel.name === "string") {
-        channelMention.add("name", channel.name);
-        mentionedChannelNames.push(channel.name);
+      // Add channel to the global collection
+      addChannelToCollection(entities, channel);
+      mentionedChannelIds.push(channel.id); // List IDs
+
+      // Get name for summary
+      const channelDetails = entities.channels.get(channel.id);
+      if (channelDetails) {
+        mentionedChannelNames.push(channelDetails.name);
       }
     });
+    if (mentionedChannelIds.length > 0) {
+      mentionsContext.add("channel-ids", mentionedChannelIds.join(", ")); // List IDs
+    }
   }
 
   if (message.mentions.roles.size > 0) {
-    const roleMentions = mentionsContext
-      .add("roles")
-      .desc("Role mentions found in the message");
     message.mentions.roles.forEach((role) => {
-      const roleMention = roleMentions
-        .add(`role-${role.id}`)
-        .desc(`Details for role mention with ID ${role.id}`);
-      roleMention.add("id", role.id);
-      roleMention.add("name", role.name);
-      mentionedRoleNames.push(role.name);
+      // Add role to the global collection
+      addRoleToCollection(entities, role);
+      mentionedRoleIds.push(role.id); // List IDs
+
+      // Get name for summary
+      const roleDetails = entities.roles.get(role.id);
+      if (roleDetails) {
+        mentionedRoleNames.push(roleDetails.name);
+      }
     });
+    if (mentionedRoleIds.length > 0) {
+      mentionsContext.add("role-ids", mentionedRoleIds.join(", ")); // List IDs
+    }
   }
 
   if (message.mentions.everyone) {
@@ -185,6 +244,7 @@ export function buildMentionsContext(context: Context, message: Message) {
     everyoneMentioned = true;
   }
 
+  // Keep the summary for quick understanding, using names looked up from collection
   const summaryParts: string[] = [];
   if (mentionedUserNames.length > 0) {
     summaryParts.push(`Users: [${mentionedUserNames.join(", ")}]`);
@@ -202,6 +262,105 @@ export function buildMentionsContext(context: Context, message: Message) {
   if (summaryParts.length > 0) {
     mentionsContext
       .add("summary", summaryParts.join("; "))
-      .desc("A concise summary of mentions");
+      .desc("A concise summary of mentions in the current message");
   }
 }
+
+// Modify buildReplyContext to use the entity collection
+export async function buildReplyContext(
+  context: Context,
+  message: Message,
+  entities: CollectedEntities,
+) {
+  // Add entities parameter
+  // Use messageId directly from the reference
+  if (!message.reference?.messageId) return;
+
+  const replyAttributes = context
+    .add("reply-data")
+    .desc("The sent message is a reply to another message");
+
+  try {
+    // Fetch the referenced message
+    const referencedMessage = await message.fetchReference();
+
+    // Add the author of the referenced message to the global collection
+    addUserToCollection(
+      entities,
+      referencedMessage.author,
+      referencedMessage.member,
+    );
+
+    // Also collect any mentions *within* the referenced message and add to global collection
+    referencedMessage.mentions.users.forEach((user) =>
+      addUserToCollection(
+        entities,
+        user,
+        referencedMessage.guild?.members.cache.get(user.id),
+      ),
+    );
+    referencedMessage.mentions.roles.forEach((role) =>
+      addRoleToCollection(entities, role),
+    );
+    referencedMessage.mentions.channels.forEach((channel) => {
+      addChannelToCollection(entities, channel);
+    });
+
+    // Add minimal details about the referenced message to the main context
+    replyAttributes.add("is-reply", "true");
+    replyAttributes.add("referenced-message-id", referencedMessage.id);
+    replyAttributes.add(
+      "referenced-message-author-id",
+      referencedMessage.author.id,
+    ); // Point to author ID in lookup
+    replyAttributes.add(
+      "referenced-message-content",
+      referencedMessage.content,
+    ); // Keep content for quick reference
+  } catch (error) {
+    replyAttributes.add(
+      "error",
+      "Could not fetch referenced message or its details",
+    );
+    // Log the error but don't fail completely
+    logger.error(
+      `Error fetching referenced message ${message.reference?.messageId}: ${error}`,
+    );
+  }
+}
+
+// Keep buildServerContext, buildChannelContext, buildDMContext, buildUserContext as they are for the *current* message
+// buildUserContext implicitly adds the current user to the collection via the call in messageCreate.ts
+
+export function buildServerContext(context: Context, message: Message) {
+  const serverAttributes = context
+    .add("server-attributes")
+    .desc("Details about the server the message was sent in");
+  serverAttributes.add("id", message.guild?.id || "");
+  serverAttributes.add("name", message.guild?.name || "");
+  serverAttributes.add(
+    "member-count",
+    message.guild?.memberCount?.toString() || "",
+  );
+}
+
+export function buildChannelContext(context: Context, message: Message) {
+  const channelAttributes = context
+    .add("channel-attributes")
+    .desc("Details about the channel the message was sent in");
+  channelAttributes.add("id", message.channel.id);
+  // @ts-ignore // Keep as is for now, assuming the name property might not always exist or be string on base Channel type
+  channelAttributes.add("name", message.channel?.name || "Unknown");
+}
+
+export function buildDMContext(context: Context, message: Message) {
+  const channelAttributes = context
+    .add("channel-attributes")
+    .desc("Details about the direct message channel");
+  channelAttributes.add("id", message.channel.id);
+  channelAttributes.add("name", "Direct Message");
+  channelAttributes.add("is-dm", "true");
+}
+
+// Note: buildUserContext is not needed in main.ts anymore as the user is added to the collection
+// and the collection is used to build the lookup. We keep the helper addUserToCollection.

--- a/utils/ai/context/main.ts
+++ b/utils/ai/context/main.ts
@@ -194,7 +194,7 @@ export async function buildReferenceContext(
 
   const referenceAttributes = context
     .add("reference-data")
-    .desc("The sent message is a reply to another message");
+    .desc("The message sent is a reply to another message");
 
   try {
     const referencedMessage = await message.fetchReference();

--- a/utils/ai/context/main.ts
+++ b/utils/ai/context/main.ts
@@ -3,7 +3,6 @@ import client from "../../../clients/discord";
 import { Context } from "../../contextBuilder";
 import { logger } from "../../logger";
 
-// Define the structure for collected entities (Exported for use in history.ts)
 export interface CollectedEntities {
   users: Map<
     string,
@@ -13,15 +12,12 @@ export interface CollectedEntities {
   channels: Map<string, { id: string; name: string }>;
 }
 
-// Helper to add user to the collection map
-// Can accept a full User/GuildMember object or just partial details if coming from history
 export function addUserToCollection(
   entities: CollectedEntities,
   user: User | { id: string; name: string; isBot?: boolean; isSelf?: boolean },
-  member?: GuildMember | null, // Optional member for nickname
+  member?: GuildMember | null,
 ) {
   if (!entities.users.has(user.id)) {
-    // If we have a full User object
     if ("displayName" in user) {
       const fullUser = user as User;
       const name = member?.nickname || fullUser.displayName;
@@ -32,7 +28,6 @@ export function addUserToCollection(
         isSelf: fullUser.id === client.user?.id,
       });
     } else {
-      // Assume it's the partial details object from history
       const partialUser = user as {
         id: string;
         name: string;
@@ -49,7 +44,6 @@ export function addUserToCollection(
   }
 }
 
-// Helper to add role to the collection map
 export function addRoleToCollection(
   entities: CollectedEntities,
   role: Role | { id: string; name: string },
@@ -62,20 +56,17 @@ export function addRoleToCollection(
   }
 }
 
-// Helper to add channel to the collection map
 export function addChannelToCollection(
   entities: CollectedEntities,
   channel: Channel | { id: string; name: string },
 ) {
   if (!entities.channels.has(channel.id)) {
-    // If we have a full Channel object (like GuildChannel)
     if ("name" in channel && typeof channel.name === "string") {
       entities.channels.set(channel.id, {
         id: channel.id,
         name: channel.name,
       });
     } else {
-      // Assume it's the partial details object
       const partialChannel = channel as { id: string; name: string };
       entities.channels.set(partialChannel.id, {
         id: partialChannel.id,
@@ -85,7 +76,6 @@ export function addChannelToCollection(
   }
 }
 
-// New function to build the centralized entity lookup context
 export function buildEntityLookupContext(
   context: Context,
   entities: CollectedEntities,
@@ -95,7 +85,7 @@ export function buildEntityLookupContext(
     entities.roles.size === 0 &&
     entities.channels.size === 0
   ) {
-    return; // Skip if no entities collected
+    return;
   }
 
   const entityDetails = context
@@ -141,13 +131,11 @@ export function buildEntityLookupContext(
   }
 }
 
-// Modify buildMentionsContext to use the entity collection
 export function buildMentionsContext(
   context: Context,
   message: Message,
   entities: CollectedEntities,
 ) {
-  // Add entities parameter
   const botMentioned = message.mentions.users.has(
     client.user?.id || "dummy_id_to_prevent_undefined_lookup",
   );
@@ -166,31 +154,29 @@ export function buildMentionsContext(
   if (!hasMentions) return;
 
   const mentionsContext = context
-    .add("mentions-in-current-message") // Rename to be specific
+    .add("mentions-in-current-message")
     .desc(
       "Information about mentions found *only* in the current message content. Refer to 'entity-details' for full information about these IDs.",
     );
 
-  const mentionedUserIds: string[] = []; // Collect IDs for listing
+  const mentionedUserIds: string[] = [];
   const mentionedChannelIds: string[] = [];
   const mentionedRoleIds: string[] = [];
   let everyoneMentioned = false;
 
-  const mentionedUserNames: string[] = []; // Still collect names for summary
+  const mentionedUserNames: string[] = [];
   const mentionedChannelNames: string[] = [];
   const mentionedRoleNames: string[] = [];
 
   if (message.mentions.users.size > 0) {
     message.mentions.users.forEach((user) => {
-      // Add user to the global collection (in case they weren't in history)
       addUserToCollection(
         entities,
         user,
         message.guild?.members.cache.get(user.id),
       );
-      mentionedUserIds.push(user.id); // List IDs in current message context
+      mentionedUserIds.push(user.id);
 
-      // Get name for summary from the collection
       const userDetails = entities.users.get(user.id);
       if (userDetails) {
         mentionedUserNames.push(
@@ -199,41 +185,37 @@ export function buildMentionsContext(
       }
     });
     if (mentionedUserIds.length > 0) {
-      mentionsContext.add("user-ids", mentionedUserIds.join(", ")); // List IDs
+      mentionsContext.add("user-ids", mentionedUserIds.join(", "));
     }
   }
 
   if (message.mentions.channels.size > 0) {
     message.mentions.channels.forEach((channel) => {
-      // Add channel to the global collection
       addChannelToCollection(entities, channel);
-      mentionedChannelIds.push(channel.id); // List IDs
+      mentionedChannelIds.push(channel.id);
 
-      // Get name for summary
       const channelDetails = entities.channels.get(channel.id);
       if (channelDetails) {
         mentionedChannelNames.push(channelDetails.name);
       }
     });
     if (mentionedChannelIds.length > 0) {
-      mentionsContext.add("channel-ids", mentionedChannelIds.join(", ")); // List IDs
+      mentionsContext.add("channel-ids", mentionedChannelIds.join(", "));
     }
   }
 
   if (message.mentions.roles.size > 0) {
     message.mentions.roles.forEach((role) => {
-      // Add role to the global collection
       addRoleToCollection(entities, role);
-      mentionedRoleIds.push(role.id); // List IDs
+      mentionedRoleIds.push(role.id);
 
-      // Get name for summary
       const roleDetails = entities.roles.get(role.id);
       if (roleDetails) {
         mentionedRoleNames.push(roleDetails.name);
       }
     });
     if (mentionedRoleIds.length > 0) {
-      mentionsContext.add("role-ids", mentionedRoleIds.join(", ")); // List IDs
+      mentionsContext.add("role-ids", mentionedRoleIds.join(", "));
     }
   }
 
@@ -244,7 +226,6 @@ export function buildMentionsContext(
     everyoneMentioned = true;
   }
 
-  // Keep the summary for quick understanding, using names looked up from collection
   const summaryParts: string[] = [];
   if (mentionedUserNames.length > 0) {
     summaryParts.push(`Users: [${mentionedUserNames.join(", ")}]`);
@@ -266,14 +247,11 @@ export function buildMentionsContext(
   }
 }
 
-// Modify buildReplyContext to use the entity collection
 export async function buildReplyContext(
   context: Context,
   message: Message,
   entities: CollectedEntities,
 ) {
-  // Add entities parameter
-  // Use messageId directly from the reference
   if (!message.reference?.messageId) return;
 
   const replyAttributes = context
@@ -281,17 +259,14 @@ export async function buildReplyContext(
     .desc("The sent message is a reply to another message");
 
   try {
-    // Fetch the referenced message
     const referencedMessage = await message.fetchReference();
 
-    // Add the author of the referenced message to the global collection
     addUserToCollection(
       entities,
       referencedMessage.author,
       referencedMessage.member,
     );
 
-    // Also collect any mentions *within* the referenced message and add to global collection
     referencedMessage.mentions.users.forEach((user) =>
       addUserToCollection(
         entities,
@@ -306,31 +281,26 @@ export async function buildReplyContext(
       addChannelToCollection(entities, channel);
     });
 
-    // Add minimal details about the referenced message to the main context
     replyAttributes.add("is-reply", "true");
     replyAttributes.add("referenced-message-id", referencedMessage.id);
     replyAttributes.add(
       "referenced-message-author-id",
       referencedMessage.author.id,
-    ); // Point to author ID in lookup
+    );
     replyAttributes.add(
       "referenced-message-content",
       referencedMessage.content,
-    ); // Keep content for quick reference
+    );
   } catch (error) {
     replyAttributes.add(
       "error",
       "Could not fetch referenced message or its details",
     );
-    // Log the error but don't fail completely
     logger.error(
       `Error fetching referenced message ${message.reference?.messageId}: ${error}`,
     );
   }
 }
-
-// Keep buildServerContext, buildChannelContext, buildDMContext, buildUserContext as they are for the *current* message
-// buildUserContext implicitly adds the current user to the collection via the call in messageCreate.ts
 
 export function buildServerContext(context: Context, message: Message) {
   const serverAttributes = context
@@ -349,7 +319,7 @@ export function buildChannelContext(context: Context, message: Message) {
     .add("channel-attributes")
     .desc("Details about the channel the message was sent in");
   channelAttributes.add("id", message.channel.id);
-  // @ts-ignore // Keep as is for now, assuming the name property might not always exist or be string on base Channel type
+  // @ts-ignore
   channelAttributes.add("name", message.channel?.name || "Unknown");
 }
 
@@ -361,6 +331,3 @@ export function buildDMContext(context: Context, message: Message) {
   channelAttributes.add("name", "Direct Message");
   channelAttributes.add("is-dm", "true");
 }
-
-// Note: buildUserContext is not needed in main.ts anymore as the user is added to the collection
-// and the collection is used to build the lookup. We keep the helper addUserToCollection.

--- a/utils/ai/context/main.ts
+++ b/utils/ai/context/main.ts
@@ -102,9 +102,11 @@ export function buildEntityLookupContext(
       const userNode = usersNode.add(id);
       userNode.add("id", details.id);
       userNode.add("name", details.name);
-      if (details.isBot) userNode.add("is-bot", "true");
-      if (details.isSelf)
+      if (details.isSelf) {
         userNode.add("is-self", "true").desc("You (@Capybot)");
+      } else if (details.isBot) {
+        userNode.add("is-bot", "true");
+      }
     }
   }
 
@@ -179,9 +181,7 @@ export function buildMentionsContext(
   }
 
   if (message.mentions.everyone) {
-    mentionsContext
-      .add("everyone", "true")
-      .desc("@everyone or @here mention");
+    mentionsContext.add("everyone", "true").desc("@everyone or @here mention");
   }
 }
 


### PR DESCRIPTION
Instead of repeating context for mentions of roles, users, and channels in the message history or giving full context data for messages themselves, the bot is now given a context dictionary at the end and can use it to "look up" things in the history by their ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced AI response context to better recognize and describe users, roles, and channels mentioned or referenced in messages.
  - Improved conversation history tracking, including richer details about message authors and mentions for more accurate AI replies.

- **Bug Fixes**
  - Improved error handling and logging when fetching referenced messages.

- **Refactor**
  - Streamlined context-building for AI by unifying entity collection and simplifying context structure for mentions and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->