### PR TITLE
feat: View sticker names & IDs in messages and allow message with no text content

### DIFF
--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -17,6 +17,7 @@ import {
   buildServerContext,
   buildAttachmentContext,
   type CollectedEntities,
+  buildStickerContext,
 } from "../utils/ai/context/main";
 import { generateAIResponse } from "../utils/ai/generateAIResponse";
 import { Context } from "../utils/contextBuilder";
@@ -73,6 +74,7 @@ export default {
       await buildReferenceContext(context, message, allMentionedEntities);
       buildMentionsContext(context, message, allMentionedEntities);
       buildAttachmentContext(context, message);
+      buildStickerContext(context, message);
       buildEntityLookupContext(context, allMentionedEntities);
 
       // Manually add additional context
@@ -87,7 +89,7 @@ export default {
 
       const currentMessageParts = [
         {
-          text: `${context.toString()}\n\n${message?.content || "Error: No message content"}`,
+          text: `${context.toString()}\n\n${message?.content}`,
         },
       ];
 

--- a/utils/ai/context/history.ts
+++ b/utils/ai/context/history.ts
@@ -7,6 +7,7 @@ import {
   addUserToCollection,
   buildAttachmentContext,
   type CollectedEntities,
+  buildStickerContext,
 } from "./main";
 
 export async function buildConversationHistory(
@@ -113,12 +114,22 @@ export async function buildConversationHistory(
           msg,
           "Details about attachments in the historical message",
         );
+        buildStickerContext(historyContext, msg);
+
+        let messageContent = msg.content;
+        if (!messageContent) {
+          historyContext
+            .add("no-content", "true")
+            .desc(
+              "The message contains no text content, so focus on attachments and stickers if present.",
+            );
+        }
 
         conversationHistory.push({
           role: "user",
           parts: [
             {
-              text: `${historyContext.toString()}\n\n${msg?.content || "Error: No message content"}`,
+              text: `${historyContext.toString()}\n\n${messageContent}`,
             },
           ],
         });

--- a/utils/ai/context/main.ts
+++ b/utils/ai/context/main.ts
@@ -234,6 +234,7 @@ export async function buildReferenceContext(
       referencedMessage,
       "Details about attachments in the referenced message",
     );
+    buildStickerContext(referenceAttributes, referencedMessage);
   } catch (error) {
     referenceAttributes.add(
       "error",
@@ -301,5 +302,22 @@ export function buildAttachmentContext(
     attachmentNode
       .add("size", attachment.size.toString())
       .desc("Size in bytes");
+  });
+}
+
+export function buildStickerContext(context: Context, message: Message) {
+  if (message.stickers.size === 0) {
+    return;
+  }
+
+  const stickersContext = context
+    .add("stickers")
+    .desc("Details about the stickers in this message");
+
+  message.stickers.forEach((sticker) => {
+    const stickerNode = stickersContext.add(sticker.id);
+    stickerNode.add("name", sticker.name || "Unknown Sticker");
+    stickerNode.add("url", sticker.url);
+    stickerNode.add("description", sticker?.description || "None provided");
   });
 }

--- a/utils/ai/tools/getAttachmentInfo.ts
+++ b/utils/ai/tools/getAttachmentInfo.ts
@@ -103,14 +103,14 @@ async function getAttachmentInfoFn({
 export const getAttachmentInfo: ToolDefinition = {
   name: "get_attachment_info",
   description:
-    "Retrieves information about an attachment (image, video, audio, or text) from a given URL. It analyzes the attachment based on a provided prompt and returns a summary.",
+    "Retrieves information about an attachment (image, video, audio, PDF, RTF, or text-based files) from a given URL. For example, you can view images, watch videos, listen to music, or summarize documents.",
   parameters: {
     type: Type.OBJECT,
     properties: {
       prompt: {
         type: Type.STRING,
         description:
-          "A detailed prompt describing what information to extract from the attachment. Be specific about the type of analysis required (e.g., in-depth analysis, general outline, key points). This should be provided by you, the model, and not the user unless they specifically request it.",
+          "A detailed prompt describing what information to extract from the attachment. Be specific about the type of analysis required (e.g., in-depth analysis, general outline, key points, basic summary). This should be provided by you, the model, and not the user unless they specifically request it.",
       },
       url: {
         type: Type.STRING,
@@ -119,7 +119,7 @@ export const getAttachmentInfo: ToolDefinition = {
       contentType: {
         type: Type.STRING,
         description:
-          "The content type of the attachment (e.g., image/png, text/plain, video/mp4, audio/mp3, application/pdf). If not provided, the tool will attempt to infer it.",
+          "The content type of the attachment (e.g., image/png). If not provided, the tool will attempt to infer it.",
       },
     },
     required: ["prompt", "url"],


### PR DESCRIPTION
Pretty simple. CapyBot can now:

* See sticker's names and IDs in current message and historical messages
* View attachments or stickers in messages with no text content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including sticker details from messages and referenced messages in AI-generated context and conversation history.

- **Improvements**
  - Enhanced handling of messages with no content by clearly indicating missing content in conversation history.
  - Updated attachment tool descriptions to explicitly mention support for PDF and RTF files and clarified usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->