### PR TITLE
feat: ignore support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ GEMINI_ATTACHMENT_MODEL='gemini-2.0-flash' # Model that analyzes attachments
 GEMINI_SEARCH_MODEL='gemini-2.0-flash' # Model that searches the web
 GEMINI_BROWSE_MODEL='gemini-2.0-flash' # Model that browses websites
 GEMINI_CODE_EXECUTION_MODEL='gemini-2.0-flash' # Model that executes Python
+
+# Ignore response phrase for AI to signal not to respond
+IGNORE_RESPONSE_PHRASE='~!IGNORE_RESPONSE~|'

--- a/bun.lock
+++ b/bun.lock
@@ -4,16 +4,16 @@
     "": {
       "name": "discraft-bot",
       "dependencies": {
-        "@google/genai": "^1.17.0",
+        "@google/genai": "^1.21.0",
         "consola": "^3.4.2",
         "discord.js": "^14.22.1",
-        "dotenv": "^17.2.2",
+        "dotenv": "^17.2.3",
         "fastest-levenshtein": "^1.0.16",
         "sqlite3": "^5.1.7",
       },
       "devDependencies": {
         "discraft": "^1.7.8",
-        "typescript": "^5.9.2",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -86,7 +86,7 @@
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
-    "@google/genai": ["@google/genai@1.19.0", "", { "dependencies": { "google-auth-library": "^9.14.2", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.11.4" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-mIMV3M/KfzzFA//0fziK472wKBJ1TdJLhozIUJKTPLyTDN1NotU+hyoHW/N0cfrcEWUK20YA0GxCeHC4z0SbMA=="],
+    "@google/genai": ["@google/genai@1.21.0", "", { "dependencies": { "google-auth-library": "^9.14.2", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.11.4" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-k47DECR8BF9z7IJxQd3reKuH2eUnOH5NlJWSe+CKM6nbXx+wH3hmtWQxUQR9M8gzWW1EvFuRVgjQssEIreNZsw=="],
 
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
@@ -184,7 +184,7 @@
 
     "discraft": ["discraft@1.7.8", "", { "dependencies": { "@clack/core": "^0.5.0", "@clack/prompts": "^0.11.0", "chokidar": "^4.0.3", "commander": "^14.0.0", "consola": "^3.4.2", "esbuild": "^0.25.5", "esbuild-node-externals": "^1.18.0", "fs-extra": "^11.3.0", "glob": "^11.0.3", "kleur": "^4.1.5" }, "bin": { "discraft": "package/dist/cli.js" } }, "sha512-Ql9/hFxzH7r4lhnai26OMi634OrTGMqiB2NJNH9xlU72ABlrnI1KQCt2SHppatiYJxeE3b5yZx/J2ZJ40zzztQ=="],
 
-    "dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
+    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
@@ -444,7 +444,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 

--- a/commands/ignore.ts
+++ b/commands/ignore.ts
@@ -1,0 +1,81 @@
+import { SlashCommandBuilder } from "discord.js";
+import { database, type IgnoreRule } from "../utils/database";
+import { logger } from "../utils/logger";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("ignore")
+    .setDescription("Ignore messages in a channel or from a user (admin only).")
+    .addUserOption((option) =>
+      option
+        .setName("user")
+        .setDescription("The user to ignore messages from.")
+        .setRequired(false),
+    )
+    .addChannelOption((option) =>
+      option
+        .setName("channel")
+        .setDescription("The channel to ignore messages in.")
+        .setRequired(false),
+    ),
+
+  handler: async (interaction: any) => {
+    if (!interaction.guild) {
+      return interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
+      });
+    }
+
+    if (!interaction.memberPermissions?.has("Administrator")) {
+      return interaction.reply({
+        content: "You need Administrator permissions to use this command.",
+        ephemeral: true,
+      });
+    }
+
+    const user = interaction.options.getUser("user");
+    const channel = interaction.options.getChannel("channel");
+
+    if (!user && !channel) {
+      return interaction.reply({
+        content: "You must specify either a user or a channel to ignore.",
+        ephemeral: true,
+      });
+    }
+
+    let scope: "server" | "channel_specific" = "server";
+    let description = "";
+
+    if (user && channel) {
+      scope = "channel_specific";
+      description = `Ignoring messages from ${user} in ${channel} for this server.`;
+    } else if (user) {
+      description = `Ignoring messages from ${user} server-wide.`;
+    } else if (channel) {
+      description = `Ignoring messages in ${channel} server-wide.`;
+    }
+
+    const rule: IgnoreRule = {
+      guildId: interaction.guild.id,
+      userId: user?.id,
+      channelId: channel?.id,
+      scope,
+    };
+
+    try {
+      await database.saveIgnoreRule(rule);
+      await interaction.reply({
+        content: description,
+        ephemeral: true,
+      });
+      logger.log(`Ignore rule added: ${JSON.stringify(rule)}`);
+    } catch (error) {
+      logger.error("Error saving ignore rule:", error);
+      await interaction.reply({
+        content: "An error occurred while setting the ignore rule.",
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/commands/ignore.ts
+++ b/commands/ignore.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { database, type IgnoreRule } from "../utils/database";
 import { logger } from "../utils/logger";
 
@@ -19,7 +19,7 @@ export default {
         .setRequired(false),
     ),
 
-  handler: async (interaction: any) => {
+  handler: async (interaction: ChatInputCommandInteraction) => {
     if (!interaction.guild) {
       return interaction.reply({
         content: "This command can only be used in a server.",

--- a/commands/ignoreStatus.ts
+++ b/commands/ignoreStatus.ts
@@ -1,4 +1,8 @@
-import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from "discord.js";
 import { database, type IgnoreRule } from "../utils/database";
 import { logger } from "../utils/logger";
 
@@ -7,7 +11,7 @@ export default {
     .setName("ignore-status")
     .setDescription("View current ignore rules for this server."),
 
-  handler: async (interaction: any) => {
+  handler: async (interaction: ChatInputCommandInteraction) => {
     if (!interaction.guild) {
       return interaction.reply({
         content: "This command can only be used in a server.",

--- a/commands/ignoreStatus.ts
+++ b/commands/ignoreStatus.ts
@@ -1,0 +1,61 @@
+import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
+import { database, type IgnoreRule } from "../utils/database";
+import { logger } from "../utils/logger";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("ignore-status")
+    .setDescription("View current ignore rules for this server."),
+
+  handler: async (interaction: any) => {
+    if (!interaction.guild) {
+      return interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
+      });
+    }
+
+    try {
+      const rules: IgnoreRule[] = await database.getIgnoreRulesByGuild(
+        interaction.guild.id,
+      );
+
+      if (rules.length === 0) {
+        return interaction.reply({
+          content: "No ignore rules are currently set for this server.",
+          ephemeral: true,
+        });
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle("Ignore Rules")
+        .setDescription("Current ignore rules for this server:")
+        .setColor(0x0099ff);
+
+      for (const rule of rules) {
+        let description = "";
+        if (rule.scope === "server") {
+          if (rule.userId) {
+            description = `Ignoring user <@${rule.userId}> server-wide.`;
+          } else if (rule.channelId) {
+            description = `Ignoring channel <#${rule.channelId}> server-wide.`;
+          }
+        } else if (rule.scope === "channel_specific") {
+          description = `Ignoring user <@${rule.userId}> in channel <#${rule.channelId}>.`;
+        }
+        embed.addFields({ name: "Rule", value: description, inline: false });
+      }
+
+      await interaction.reply({
+        embeds: [embed],
+        ephemeral: true,
+      });
+    } catch (error) {
+      logger.error("Error getting ignore rules:", error);
+      await interaction.reply({
+        content: "An error occurred while retrieving ignore rules.",
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/commands/ignoreStatus.ts
+++ b/commands/ignoreStatus.ts
@@ -43,9 +43,13 @@ export default {
             description = `Ignoring user <@${rule.userId}> server-wide.`;
           } else if (rule.channelId) {
             description = `Ignoring channel <#${rule.channelId}> server-wide.`;
+          } else {
+            description = "Invalid rule (no target specified).";
           }
         } else if (rule.scope === "channel_specific") {
           description = `Ignoring user <@${rule.userId}> in channel <#${rule.channelId}>.`;
+        } else {
+          description = "Unknown rule type.";
         }
         embed.addFields({ name: "Rule", value: description, inline: false });
       }

--- a/commands/unignore.ts
+++ b/commands/unignore.ts
@@ -1,0 +1,83 @@
+import { SlashCommandBuilder } from "discord.js";
+import { database } from "../utils/database";
+import { logger } from "../utils/logger";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("unignore")
+    .setDescription("Remove an ignore rule for a channel or user (admin only).")
+    .addUserOption((option) =>
+      option
+        .setName("user")
+        .setDescription("The user to stop ignoring.")
+        .setRequired(false),
+    )
+    .addChannelOption((option) =>
+      option
+        .setName("channel")
+        .setDescription("The channel to stop ignoring.")
+        .setRequired(false),
+    ),
+
+  handler: async (interaction: any) => {
+    if (!interaction.guild) {
+      return interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
+      });
+    }
+
+    if (!interaction.memberPermissions?.has("Administrator")) {
+      return interaction.reply({
+        content: "You need Administrator permissions to use this command.",
+        ephemeral: true,
+      });
+    }
+
+    const user = interaction.options.getUser("user");
+    const channel = interaction.options.getChannel("channel");
+
+    if (!user && !channel) {
+      return interaction.reply({
+        content: "You must specify either a user or a channel to unignore.",
+        ephemeral: true,
+      });
+    }
+
+    let description = "";
+    let scope = "";
+
+    if (user && channel) {
+      scope = "channel_specific";
+      description = `No longer ignoring messages from ${user} in ${channel}.`;
+    } else if (user) {
+      scope = "server";
+      description = `No longer ignoring messages from ${user} server-wide.`;
+    } else if (channel) {
+      scope = "server";
+      description = `No longer ignoring messages in ${channel} server-wide.`;
+    }
+
+    try {
+      await database.deleteIgnoreRule(
+        interaction.guild.id,
+        user?.id,
+        channel?.id,
+        scope,
+      );
+      await interaction.reply({
+        content: description,
+        ephemeral: true,
+      });
+      logger.log(
+        `Ignore rule removed for guild ${interaction.guild.id}, user ${user?.id}, channel ${channel?.id}, scope ${scope}`,
+      );
+    } catch (error) {
+      logger.error("Error deleting ignore rule:", error);
+      await interaction.reply({
+        content: "An error occurred while removing the ignore rule.",
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/commands/unignore.ts
+++ b/commands/unignore.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { database } from "../utils/database";
 import { logger } from "../utils/logger";
 
@@ -19,7 +19,7 @@ export default {
         .setRequired(false),
     ),
 
-  handler: async (interaction: any) => {
+  handler: async (interaction: ChatInputCommandInteraction) => {
     if (!interaction.guild) {
       return interaction.reply({
         content: "This command can only be used in a server.",

--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -171,7 +171,24 @@ export default {
           logger.log(
             "AI response contains ignore phrase, skipping Discord reply.",
           );
-          return; // Don't send anything
+
+          // Cleanup any AI response parts created with tempResponseId
+          const tempParts =
+            await database.getAIResponsePartsByMessageId(tempResponseId);
+          if (tempParts.length > 0) {
+            try {
+              await database.deleteAIResponsePartsByMessageId(tempResponseId);
+              logger.log(
+                `Successfully cleaned up ${tempParts.length} AI response parts for temporary response ID: ${tempResponseId}`,
+              );
+            } catch (cleanupError) {
+              logger.error(
+                `Failed to clean up ${tempParts.length} AI response parts for temporary response ID ${tempResponseId}: ${cleanupError}`,
+              );
+            }
+          }
+
+          return;
         }
 
         let trimmedResponse;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "discraft-bot",
   "private": true,
-  "version": "0.0.0-beta.33",
+  "version": "0.0.0-beta.34",
   "description": "Bot created with discraft",
   "module": "index.ts",
   "type": "module",
@@ -16,13 +16,13 @@
   },
   "devDependencies": {
     "discraft": "^1.7.8",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@google/genai": "^1.19.0",
+    "@google/genai": "^1.21.0",
     "consola": "^3.4.2",
     "discord.js": "^14.22.1",
-    "dotenv": "^17.2.2",
+    "dotenv": "^17.2.3",
     "fastest-levenshtein": "^1.0.16",
     "sqlite3": "^5.1.7"
   },

--- a/utils/ai/systemInstruction.ts
+++ b/utils/ai/systemInstruction.ts
@@ -25,7 +25,12 @@ Some functions have specific notes so you can understand them better. They are l
 
 - \`add_reaction\`: You use this function often, for fun or when applicable.
 - \`get_attachment_info\`: This tool is very broad, don't be tricked by the name! It can help you view images, watch videos, analyze audio, read PDFs and other files, and more. You use it when responding to a message that contains an attachment unless the user tells you not to.
-- \`generate_image\`: The tool returns an image URL based on your prompt. You should use markdown to embed the image in your response. Do NOT use the format with an exclamation mark (\`![<image description>](<image_url>)\`), use the format for a link (\`[Image](<image_url>)\`). If you don't provide the URL in your response, the user can't see the image! Don't ask the user to open the URL, though, because Discord will automatically preview the image for them.
+ - \`generate_image\`: The tool returns an image URL based on your prompt. You should use markdown to embed the image in your response. Do NOT use the format with an exclamation mark (\`![<image description>](<image_url>)\`), use the format for a link (\`[Image](<image_url>)\`). If you don't provide the URL in your response, the user can't see the image! Don't ask the user to open the URL, though, because Discord will automatically preview the image for them.
+
+# Ignore Response
+You may choose not to respond to the user's message if you determine that it is not relevant, necessary, or appropriate, or if the user asks you not to.
+If you decide not to respond to the user's message, output the phrase "${process.env.IGNORE_RESPONSE_PHRASE || "~!IGNORE_RESPONSE~|"}" anywhere in your response, and nothing else. This will prevent your response from being sent to Discord.
+If you want to only use a function or functions and NOT send a response message, you should call the function(s) first (they will be executed in order), then output the ignore phrase to prevent a response message from being sent.
 `,
     },
   ],

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -126,6 +126,9 @@ class Database {
       this.db.run(
         "CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON conversation_messages(timestamp)",
       );
+      this.db.run(
+        "CREATE INDEX IF NOT EXISTS idx_ignore_rules_guild_id ON ignore_rules(guild_id)",
+      );
     });
   }
 
@@ -214,6 +217,29 @@ class Database {
               order: row.order_num,
             }));
             resolve(parts);
+          }
+        },
+      );
+    });
+  }
+
+  deleteAIResponsePartsByMessageId(messageId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.db.run(
+        "DELETE FROM ai_response_parts WHERE message_id = ?",
+        [messageId],
+        (err) => {
+          if (err) {
+            logger.error(
+              `Error deleting AI response parts for messageId ${messageId}:`,
+              err,
+            );
+            reject(err);
+          } else {
+            logger.info(
+              `Successfully deleted AI response parts for messageId: ${messageId}`,
+            );
+            resolve();
           }
         },
       );

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -40,6 +40,15 @@ export interface ConversationMessage {
   aiResponseParts?: AIResponsePart[];
 }
 
+export interface IgnoreRule {
+  id?: number;
+  guildId: string;
+  userId?: string;
+  channelId?: string;
+  scope: "server" | "channel_specific";
+  createdAt?: string;
+}
+
 class Database {
   private db: sqlite3.Database;
   private dbPath: string;
@@ -79,20 +88,33 @@ class Database {
     `;
 
     const createConversationMessagesTable = `
-      CREATE TABLE IF NOT EXISTS conversation_messages (
-        id TEXT PRIMARY KEY,
-        channel_id TEXT NOT NULL,
-        author_id TEXT NOT NULL,
-        content TEXT,
-        timestamp TEXT NOT NULL,
-        is_bot INTEGER NOT NULL,
-        reply_to_message_id TEXT
-      )
-    `;
+       CREATE TABLE IF NOT EXISTS conversation_messages (
+         id TEXT PRIMARY KEY,
+         channel_id TEXT NOT NULL,
+         author_id TEXT NOT NULL,
+         content TEXT,
+         timestamp TEXT NOT NULL,
+         is_bot INTEGER NOT NULL,
+         reply_to_message_id TEXT
+       )
+     `;
+
+    const createIgnoreRulesTable = `
+       CREATE TABLE IF NOT EXISTS ignore_rules (
+         id INTEGER PRIMARY KEY AUTOINCREMENT,
+         guild_id TEXT NOT NULL,
+         user_id TEXT,
+         channel_id TEXT,
+         scope TEXT NOT NULL CHECK (scope IN ('server', 'channel_specific')),
+         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+         UNIQUE(guild_id, user_id, channel_id, scope)
+       )
+     `;
 
     this.db.serialize(() => {
       this.db.run(createAIResponsePartsTable);
       this.db.run(createConversationMessagesTable);
+      this.db.run(createIgnoreRulesTable);
 
       // Create indexes for better performance
       this.db.run(
@@ -328,6 +350,89 @@ class Database {
             resolve();
           },
         );
+      });
+    });
+  }
+
+  // Ignore Rules methods
+  saveIgnoreRule(rule: IgnoreRule): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const stmt = this.db.prepare(`
+         INSERT OR REPLACE INTO ignore_rules (guild_id, user_id, channel_id, scope)
+         VALUES (?, ?, ?, ?)
+       `);
+
+      stmt.run(
+        [rule.guildId, rule.userId || null, rule.channelId || null, rule.scope],
+        (err) => {
+          if (err) {
+            logger.error("Error saving ignore rule:", err);
+            reject(err);
+          } else {
+            resolve();
+          }
+        },
+      );
+
+      stmt.finalize();
+    });
+  }
+
+  getIgnoreRulesByGuild(guildId: string): Promise<IgnoreRule[]> {
+    return new Promise((resolve, reject) => {
+      this.db.all(
+        "SELECT * FROM ignore_rules WHERE guild_id = ? ORDER BY created_at DESC",
+        [guildId],
+        (err, rows: any[]) => {
+          if (err) {
+            logger.error("Error getting ignore rules:", err);
+            reject(err);
+          } else {
+            const rules: IgnoreRule[] = rows.map((row) => ({
+              id: row.id,
+              guildId: row.guild_id,
+              userId: row.user_id,
+              channelId: row.channel_id,
+              scope: row.scope,
+              createdAt: row.created_at,
+            }));
+            resolve(rules);
+          }
+        },
+      );
+    });
+  }
+
+  deleteIgnoreRule(
+    guildId: string,
+    userId?: string,
+    channelId?: string,
+    scope?: string,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let query = "DELETE FROM ignore_rules WHERE guild_id = ?";
+      const params: any[] = [guildId];
+
+      if (userId) {
+        query += " AND user_id = ?";
+        params.push(userId);
+      }
+      if (channelId) {
+        query += " AND channel_id = ?";
+        params.push(channelId);
+      }
+      if (scope) {
+        query += " AND scope = ?";
+        params.push(scope);
+      }
+
+      this.db.run(query, params, (err) => {
+        if (err) {
+          logger.error("Error deleting ignore rule:", err);
+          reject(err);
+        } else {
+          resolve();
+        }
       });
     });
   }


### PR DESCRIPTION
BETA support for ignoring users, channels, and messages server-wide.
CapyBot can decide to ignore messages and admins can configure channels and users to be ignored by CapyBot in their server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin slash commands (/ignore, /unignore, /ignore-status) to manage where and whom the bot responds to.
  * Bot now respects persistent server/channel ignore rules and can show current rules.
  * Added configurable non-response phrase (env var) so the bot can intentionally skip sending a reply when appropriate.

* **Chores**
  * Bumped app version to 0.0.0-beta.34 and updated dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->